### PR TITLE
chore(ci): drop deprecated and add latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [9, 10, 11, 12, 13, 14, 15]
+        version: [13, 14, 15, 16, 17]
     steps:
        - name: Login to DockerHub
          uses: docker/login-action@v1


### PR DESCRIPTION
Drops 9, 10, 11, 12 and adds 16 and 17

See: https://endoflife.date/postgresql