### PR TITLE
chore: add metadata labels to container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         version: [13, 14, 15, 16, 17]
     steps:
+       - name: Docker meta
+         id: meta
+         uses: docker/metadata-action@v5
        - name: Login to DockerHub
          uses: docker/login-action@v3
          with:
@@ -28,3 +31,4 @@ jobs:
            build-args: |
              POSTGRES_VERSION=${{ matrix.version }}
            tags: siemens/postgres-backup-s3:${{ matrix.version }}
+           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This is useful for downstream tools like Renovate to understand where the image is coming from, from which commit it was built and which license applies.